### PR TITLE
Add nodal directors

### DIFF
--- a/src/main/java/net/countercraft/movecraft/combat/MovecraftCombat.java
+++ b/src/main/java/net/countercraft/movecraft/combat/MovecraftCombat.java
@@ -72,6 +72,8 @@ public final class MovecraftCombat extends JavaPlugin {
         CombatRelease.load(getConfig());
 
         Directors.load(getConfig());
+        CannonDirectors.load(getConfig());
+        AADirectors.load(getConfig());
 
         MovementTracers.load(getConfig());
         TNTTracers.load(getConfig());

--- a/src/main/java/net/countercraft/movecraft/combat/features/directors/AADirectors.java
+++ b/src/main/java/net/countercraft/movecraft/combat/features/directors/AADirectors.java
@@ -77,17 +77,38 @@ public class AADirectors extends Directors implements Listener {
 
         Player p = getDirector((PlayerCraft) c);
 
-        MovecraftLocation midPoint = c.getHitBox().getMidPoint();
-        int distX = Math.abs(midPoint.getX() - fireball.getLocation().getBlockX());
-        int distY = Math.abs(midPoint.getY() - fireball.getLocation().getBlockY());
-        int distZ = Math.abs(midPoint.getZ() - fireball.getLocation().getBlockZ());
-        if (distX > AADirectorDistance || distY > AADirectorDistance || distZ > AADirectorDistance)
-            return;
-
         fireball.setShooter(p);
 
         if (p == null || p.getInventory().getItemInMainHand().getType() != Directors.DirectorTool)
             return;
+
+        if (AllowNodeDirectors && !getSignStrings(p).isEmpty()) {
+            for (MovecraftLocation location : c.getHitBox()) {
+                Block block = c.getWorld().getBlockAt(location.getX(), location.getY(), location.getZ());
+                if (!(block.getState() instanceof Sign))
+                    continue;
+
+                Sign sign = (Sign) block.getState();
+
+                if (sign.getLine(0).equalsIgnoreCase("subcraft rotate") && !sign.getLine(3).isBlank() && getSignStrings(p).contains(sign.getLine(3))) {
+                    int distX = Math.abs(location.getX() - fireball.getLocation().getBlockX());
+                    int distY = Math.abs(location.getY() - fireball.getLocation().getBlockY());
+                    int distZ = Math.abs(location.getZ() - fireball.getLocation().getBlockZ());
+                    if (!hasDirector((PlayerCraft) c) || distX >= AADirectorDistance
+                            || distY >= AADirectorDistance || distZ >= AADirectorDistance)
+                        return;
+                }
+            }
+        } else {
+            MovecraftLocation midpoint = c.getHitBox().getMidPoint();
+            int distX = Math.abs(midpoint.getX() - fireball.getLocation().getBlockX());
+            int distY = Math.abs(midpoint.getY() - fireball.getLocation().getBlockY());
+            int distZ = Math.abs(midpoint.getZ() - fireball.getLocation().getBlockZ());
+
+            if (!hasDirector((PlayerCraft) c) || distX >= AADirectorDistance
+                    || distY >= AADirectorDistance || distZ >= AADirectorDistance)
+                return;
+        }
 
         Vector fireballVector = fireball.getVelocity();
         double speed = fireballVector.length(); // store the speed to add it back in later, since all the values we will be using are "normalized", IE: have a speed of 1
@@ -178,7 +199,7 @@ public class AADirectors extends Directors implements Listener {
         }
 
         clearDirector(p);
-        addDirector(foundCraft, p);
+        addDirector(foundCraft, p, sign.getLine(1), sign.getLine(2), sign.getLine(3));
         p.sendMessage(I18nSupport.getInternationalisedString("AADirector - Directing"));
     }
 }

--- a/src/main/java/net/countercraft/movecraft/combat/features/directors/CannonDirectors.java
+++ b/src/main/java/net/countercraft/movecraft/combat/features/directors/CannonDirectors.java
@@ -56,7 +56,7 @@ public class CannonDirectors extends Directors implements Listener {
     }
 
     public static void load(@NotNull FileConfiguration config) {
-        CannonDirectorDistance = config.getInt("CannonDirectorsDistance", 100);
+        CannonDirectorDistance = config.getInt("CannonDirectorDistance", 100);
         CannonDirectorRange = config.getInt("CannonDirectorRange", 120);
     }
 

--- a/src/main/java/net/countercraft/movecraft/combat/features/directors/CannonDirectors.java
+++ b/src/main/java/net/countercraft/movecraft/combat/features/directors/CannonDirectors.java
@@ -98,17 +98,37 @@ public class CannonDirectors extends Directors implements Listener {
         if (!(c instanceof PlayerCraft))
             return;
 
-        MovecraftLocation midpoint = c.getHitBox().getMidPoint();
-        int distX = Math.abs(midpoint.getX() - tnt.getLocation().getBlockX());
-        int distY = Math.abs(midpoint.getY() - tnt.getLocation().getBlockY());
-        int distZ = Math.abs(midpoint.getZ() - tnt.getLocation().getBlockZ());
-        if (!hasDirector((PlayerCraft) c) || distX >= CannonDirectorDistance
-                || distY >= CannonDirectorDistance || distZ >= CannonDirectorDistance)
-            return;
-
         Player p = getDirector((PlayerCraft) c);
         if (p == null || p.getInventory().getItemInMainHand().getType() != Directors.DirectorTool)
             return;
+
+        if (AllowNodeDirectors && !getSignStrings(p).isEmpty()) {
+            for (MovecraftLocation location : c.getHitBox()) {
+                Block block = c.getWorld().getBlockAt(location.getX(), location.getY(), location.getZ());
+                if (!(block.getState() instanceof Sign))
+                    continue;
+
+                Sign sign = (Sign) block.getState();
+
+                if (sign.getLine(0).equalsIgnoreCase("subcraft rotate") && !sign.getLine(3).isBlank() && getSignStrings(p).contains(sign.getLine(3))) {
+                    int distX = Math.abs(location.getX() - tnt.getLocation().getBlockX());
+                    int distY = Math.abs(location.getY() - tnt.getLocation().getBlockY());
+                    int distZ = Math.abs(location.getZ() - tnt.getLocation().getBlockZ());
+                    if (!hasDirector((PlayerCraft) c) || distX >= CannonDirectorDistance
+                            || distY >= CannonDirectorDistance || distZ >= CannonDirectorDistance)
+                        return;
+                }
+            }
+        } else {
+            MovecraftLocation midpoint = c.getHitBox().getMidPoint();
+            int distX = Math.abs(midpoint.getX() - tnt.getLocation().getBlockX());
+            int distY = Math.abs(midpoint.getY() - tnt.getLocation().getBlockY());
+            int distZ = Math.abs(midpoint.getZ() - tnt.getLocation().getBlockZ());
+
+            if (!hasDirector((PlayerCraft) c) || distX >= CannonDirectorDistance
+                    || distY >= CannonDirectorDistance || distZ >= CannonDirectorDistance)
+                return;
+        }
 
         // Store the speed to add it back in later, since all the values we will be using are "normalized", IE: have a speed of 1
         // We're only interested in the horizontal speed for now since that's all directors *should* affect.
@@ -208,7 +228,7 @@ public class CannonDirectors extends Directors implements Listener {
         }
 
         clearDirector(p);
-        addDirector(foundCraft, p);
+        addDirector(foundCraft, p, sign.getLine(1), sign.getLine(2), sign.getLine(3));
         p.sendMessage(I18nSupport.getInternationalisedString("CannonDirector - Directing"));
     }
 

--- a/src/main/java/net/countercraft/movecraft/combat/features/directors/Directors.java
+++ b/src/main/java/net/countercraft/movecraft/combat/features/directors/Directors.java
@@ -1,24 +1,31 @@
 package net.countercraft.movecraft.combat.features.directors;
 
 import com.google.common.collect.HashBiMap;
+import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.combat.MovecraftCombat;
 import net.countercraft.movecraft.craft.PlayerCraft;
 import net.countercraft.movecraft.util.Tags;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.Sign;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class Directors extends BukkitRunnable {
     private static final Set<Directors> instances = new HashSet<>();
+    public static boolean AllowNodeDirectors;
     public static Material DirectorTool = null;
     public static Set<Material> Transparent = null;
     private final HashBiMap<PlayerCraft, Player> directors = HashBiMap.create();
+    private Map<Player, HashSet<String>> selectedSigns = new HashMap<>();
 
 
     public Directors() {
@@ -53,6 +60,17 @@ public class Directors extends BukkitRunnable {
                 MovecraftCombat.getInstance().getLogger().severe("Failed to load transparent " + o.toString());
             }
         }
+
+        Object allowNodes = config.get("AllowNodeDirectors");
+        boolean allowNodeDirectors = false;
+        if (!(allowNodes instanceof Boolean)) {
+            MovecraftCombat.getInstance().getLogger().severe("Failed load AllowNodeDirectors setting.");
+            AllowNodeDirectors = allowNodeDirectors;
+        } else {
+            AllowNodeDirectors = (boolean) allowNodes;
+        }
+
+
     }
 
     @Override
@@ -60,12 +78,30 @@ public class Directors extends BukkitRunnable {
 
     }
 
-
-    public void addDirector(@NotNull PlayerCraft craft, @NotNull Player player) {
+    public void addDirector(@NotNull PlayerCraft craft, @NotNull Player player,
+                            @Nullable String string1, @Nullable String string2, @Nullable String string3) {
         if (directors.containsValue(player))
             directors.inverse().remove(player);
 
         directors.put(craft, player);
+
+        if (!AllowNodeDirectors)
+            return;
+
+        if (selectedSigns.containsKey(player))
+            selectedSigns.remove(player);
+
+        HashSet<String> signs = new HashSet<>();
+        if (string1 != null) {
+            signs.add(string1);
+        }
+        if (string2 != null) {
+            signs.add(string2);
+        }
+        if (string3 != null) {
+            signs.add(string3);
+        }
+        selectedSigns.put(player, signs);
     }
 
     public boolean isDirector(@NotNull Player player) {
@@ -96,5 +132,9 @@ public class Directors extends BukkitRunnable {
             return null;
 
         return director;
+    }
+
+    public HashSet<String> getSignStrings(@NotNull Player player) {
+        return selectedSigns.get(player);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,6 +11,9 @@ AADirectorRange: 120 # Max range at which it will direct to a block vs in the ge
 CannonDirectorDistance: 100 # Max range at which TNT will be redirected
 CannonDirectorRange: 120 # Max range at which it will direct to a block vs in the general direction
 
+# Nodal Directors
+AllowNodeDirectors: false # Turning this on will allow you to direct selected cannons on your ship.
+                          # However, keep in mind that you will have to adjust CannonDirectorDistance and AADirectorDistance to a lower value as it calculates the distance from the subcraft rotate sign.
 # Directors
 DirectorTool: STICK # Material name for director control.
 TransparentBlocks: # List of MATERIAL_NAMES which are ignored for directing.  See https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html for a full list.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -47,9 +47,12 @@ FireballLifespan: 6 # Lifespan of fireballs in seconds
 # TNT Tracers
 TracerRateTicks: 5.0 # Rate at which tracers are spawned on the path of flying TNT
 TracerMinDistance: 60 # Minimum distance at which glowstone tracers are spawned on explosion
+TracerExplosionDelayTicks: 20 #Delay for the tracer explosion to appear
+TracerDelayTicks: 5 #Delay for the tracers to appear
 TracerParticles: FIREWORKS_SPARK # Particle to use for particle tracers  See https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Particle.html for options.
 ExplosionParticles: VILLAGER_ANGRY # Particle to use for particle tracer explosions
-
+TracerBlock: COBWEB #Block to use for block tracers
+TracerExplosionBlock: GLOWSTONE #Block to use to indicate tracer explosions
 
 ### Custom features
 


### PR DESCRIPTION
This is the first prototype, feel free to test this, but I will note a few peculiarities here:

1. Set CannonDirectorDistance and AADirectorDistance to 14 and 5 respectively. The reason why CannonDirectorDistance is around 14 is that the position the TNT the director picks up is about 10-11 blocks away from the turret sign. 
2. This code may not be the most optimized. What I have in mind is if these subcraft signs can be stored when a pilot craft so the entire craft hitbox doesn't have to be referenced every time. I'm not sure where I should put this data, however. There is also the complication of updating the movecraft location whenever a craft translates or rotates. 
3. If there are no subcraft rotate signs assigned to the cannon director sign, it will by default direct all weapons of that type. I'm not sure if this is the most intuitive method, but it will allow people to put "All weapons" under cannon directors to fire all weapons. 
4. The last thing I couldn't figure out is how to get two players to share the same director on the craft. I think directors have to be overhauled in terms of structure in order to accommodate this feature. However, I'm not sure how. 

