### PR TITLE
TNTTracking Event Fix

### DIFF
--- a/src/main/java/net/countercraft/movecraft/combat/features/tracking/TNTTracking.java
+++ b/src/main/java/net/countercraft/movecraft/combat/features/tracking/TNTTracking.java
@@ -22,6 +22,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockDispenseEvent;
+import org.bukkit.event.entity.EntitySpawnEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
@@ -145,5 +146,12 @@ public class TNTTracking implements Listener {
 
         CraftFireWeaponEvent event = new CraftFireWeaponEvent(playerCraft, new TNTCannon());
         Bukkit.getPluginManager().callEvent(event);
+    }
+
+    @EventHandler
+    public void onEntitySpawn (@NotNull EntitySpawnEvent e) {
+        if(e.getEntityType().equals(EntityType.PRIMED_TNT)) {
+            Bukkit.getServer().broadcastMessage("TNT created!");
+        }
     }
 }

--- a/src/main/java/net/countercraft/movecraft/combat/features/tracking/TNTTracking.java
+++ b/src/main/java/net/countercraft/movecraft/combat/features/tracking/TNTTracking.java
@@ -80,25 +80,6 @@ public class TNTTracking implements Listener {
         return v;
     }
 
-    private boolean subtractItem(@NotNull Inventory inv, @NotNull ItemStack item) {
-        int count = item.getAmount();
-        for (int i = 0; i < inv.getSize(); i++) {
-            ItemStack temp = inv.getItem(i);
-            if (temp == null || !temp.isSimilar(item))
-                continue;
-
-            if (temp.getAmount() <= count) {
-                count -= temp.getAmount();
-                inv.remove(temp);
-            } else {
-                temp.setAmount(temp.getAmount() - count);
-                return true;
-            }
-        }
-        return false;
-    }
-
-
     @EventHandler
     public void onEntitySpawn (@NotNull EntitySpawnEvent e) {
         if (!DamageTracking.EnableTNTTracking)
@@ -134,7 +115,7 @@ public class TNTTracking implements Listener {
             sender = playerCraft.getPilot();
         if (sender == null)
             return;
-        
+
         tnt.setMetadata("MCC-Sender", new FixedMetadataValue(MovecraftCombat.getInstance(), sender.getUniqueId().toString()));
 
         CraftFireWeaponEvent event = new CraftFireWeaponEvent(playerCraft, new TNTCannon());

--- a/src/main/java/net/countercraft/movecraft/combat/features/tracking/TNTTracking.java
+++ b/src/main/java/net/countercraft/movecraft/combat/features/tracking/TNTTracking.java
@@ -14,6 +14,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -96,41 +98,32 @@ public class TNTTracking implements Listener {
         return false;
     }
 
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onBlockDispense(@NotNull BlockDispenseEvent e) {
+
+    @EventHandler
+    public void onEntitySpawn (@NotNull EntitySpawnEvent e) {
         if (!DamageTracking.EnableTNTTracking)
             return;
-        if (e.getBlock().getType() != Material.DISPENSER || e.getItem().getType() != Material.TNT)
+        if(!e.getEntityType().equals(EntityType.PRIMED_TNT))
             return;
-
-        // Cancel dispense event
-        e.setCancelled(true);
-
-        // Subtract item yourself
-        Dispenser d = (Dispenser) e.getBlock().getState();
-        Inventory inv = d.getInventory();
-        if (!subtractItem(inv, e.getItem())) {
-            Bukkit.getScheduler().runTask(MovecraftCombat.getInstance(), () -> {
-                subtractItem(inv, e.getItem());
-            });
-        }
-
-        // Spawn TNT
-        Location l = e.getVelocity().toLocation(e.getBlock().getWorld());
-        TNTPrimed tnt = (TNTPrimed) e.getBlock().getWorld().spawnEntity(l, EntityType.PRIMED_TNT);
-        Vector velocity = getTNTVector();
-        tnt.setVelocity(velocity);
-        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-            p.playSound(l, Sound.ENTITY_TNT_PRIMED, 1.5f, 1.5f);
-        }
+        TNTPrimed tnt = (TNTPrimed)e.getEntity();
 
         // Find nearest craft
         Craft craft = MathUtils.fastNearestCraftToLoc(CraftManager.getInstance().getCrafts(),
-                e.getBlock().getLocation());
+                tnt.getLocation());
         if (!(craft instanceof PlayerCraft))
             return;
-        if (!craft.getHitBox().contains(MathUtils.bukkit2MovecraftLoc(e.getBlock().getLocation())))
-            return;
+        if (!craft.getHitBox().contains(MathUtils.bukkit2MovecraftLoc(tnt.getLocation()))) {
+            //check adjacent blocks
+            boolean found = false;
+            Block center = tnt.getLocation().getBlock();
+            for (BlockFace face : BlockFace.values()) {
+                if (craft.getHitBox().contains(MathUtils.bukkit2MovecraftLoc(center.getRelative(face).getLocation()))) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) return;
+        }
 
         // Report to tracking
         PlayerCraft playerCraft = (PlayerCraft) craft;
@@ -142,16 +135,10 @@ public class TNTTracking implements Listener {
         if (sender == null)
             return;
 
+        Bukkit.getServer().broadcastMessage("Debug: TNT Found!");
         tnt.setMetadata("MCC-Sender", new FixedMetadataValue(MovecraftCombat.getInstance(), sender.getUniqueId().toString()));
 
         CraftFireWeaponEvent event = new CraftFireWeaponEvent(playerCraft, new TNTCannon());
         Bukkit.getPluginManager().callEvent(event);
-    }
-
-    @EventHandler
-    public void onEntitySpawn (@NotNull EntitySpawnEvent e) {
-        if(e.getEntityType().equals(EntityType.PRIMED_TNT)) {
-            Bukkit.getServer().broadcastMessage("TNT created!");
-        }
     }
 }

--- a/src/main/java/net/countercraft/movecraft/combat/features/tracking/TNTTracking.java
+++ b/src/main/java/net/countercraft/movecraft/combat/features/tracking/TNTTracking.java
@@ -134,8 +134,7 @@ public class TNTTracking implements Listener {
             sender = playerCraft.getPilot();
         if (sender == null)
             return;
-
-        Bukkit.getServer().broadcastMessage("Debug: TNT Found!");
+        
         tnt.setMetadata("MCC-Sender", new FixedMetadataValue(MovecraftCombat.getInstance(), sender.getUniqueId().toString()));
 
         CraftFireWeaponEvent event = new CraftFireWeaponEvent(playerCraft, new TNTCannon());

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -52,7 +52,7 @@ ExplosionParticles: VILLAGER_ANGRY # Particle to use for particle tracer explosi
 
 # Damage Tracking
 EnableFireballTracking: false # Enable tracking and recording of fireballs (higher lag than other tracking methods)
-EnableTNTTracking: false # Enable tracking and recording of TNT damage (please read the wiki page before enabling!)
+EnableTNTTracking: false # Enable tracking and recording of TNT damage
 EnableTorpedoTracking: false # Enable tracking and recording of Torpedo damage
 DamageTimeout: 300 # Timeout for damages in seconds
 


### PR DESCRIPTION
This fix removes the hack that replaced the vanilla dispenser event. Newer versions of the game properly detect TNT spawning, so the event replacement is unnecessary, and causes bugs when firing weapons while moving.