### PR TITLE
Fix: Blast resistance float values

### DIFF
--- a/src/main/java/net/countercraft/movecraft/combat/features/BlastResistanceOverride.java
+++ b/src/main/java/net/countercraft/movecraft/combat/features/BlastResistanceOverride.java
@@ -33,12 +33,10 @@ public class BlastResistanceOverride {
             EnumSet<Material> materials = Tags.parseMaterials(entry.getKey());
             for (Material m : materials) {
                 float value;
-                if (entry.getValue() instanceof Float) {
-                    value = (float) entry.getValue();
-                } else if (entry.getValue() instanceof Integer) {
-                    int intVal = (int) entry.getValue();
-                    value = (float) intVal;
-                } else {
+                String valStr = entry.getValue().toString();
+                try {
+                    value = Float.parseFloat(valStr);
+                } catch(NumberFormatException | NullPointerException ex) {
                     MovecraftCombat.getInstance().getLogger()
                             .warning("Unable to load " + m.name() + ": " + entry.getValue());
                     continue;


### PR DESCRIPTION
Fixes floating point values (e.g. 4.2) not being loaded.

Most likely it gets loaded as a double value.

The old code uses instanceof Integer / instanceof Float checks. 
Instead one should use Float.parseFloat(string), that always returns a float and is the cleaner way imo.